### PR TITLE
feat: add reuseLoadPromise (issues #16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ interface YMapComponentsProviderProps {
   }) => any
   onError: (e?: unknown) => void
   children: ReactNode | ReactNode []
+  reuseLoadPromise?: boolean;
 }
 ```
 


### PR DESCRIPTION
Add bool flag for reuse load script promise. 
This is necessary to avoid repeated insertion of the script when there are two or more providers

```
// ComponentA
<YMapComponentsProvider apiKey={process.env.REACT_APP_YMAP_KEY}>
      <YMap location={location}></YMap>
</YMapComponentsProvider>

// ComponentB
<YMapComponentsProvider apiKey={process.env.REACT_APP_YMAP_KEY}>
      <YMap location={location}></YMap>
</YMapComponentsProvider>
```
you can see error `ymaps3: already defined`